### PR TITLE
commande update:dossier:all 

### DIFF
--- a/cartads/commands.php
+++ b/cartads/commands.php
@@ -1,8 +1,10 @@
 <?php
 
+use cartADS\Commands\UpdateAllDossiers;
 use cartADS\Commands\UpdateDossiers;
 
 
 if (isset($application)) {
     $application->add(new UpdateDossiers());
+    $application->add(new UpdateAllDossiers);
 }

--- a/cartads/lib/Commands/UpdateAllDossiers.php
+++ b/cartads/lib/Commands/UpdateAllDossiers.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace cartADS\Commands;
+
+use Jelix\Scripts\ModuleCommandAbstract;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use cartADS\dbClient as cartAdsDbClient;
+use cartADS\Util as cartAdsUtil;
+use cartADS\AdsCsApiClient as cartAdsApiClient;
+use carAds\ResultUpdateDossiers;
+use cartADS\UpdateDossierAbstract;
+
+class UpdateAllDossiers extends UpdateDossierAbstract
+{
+    protected function configure()
+    {
+        $this->setName('cartads:dossiers:update:all')
+            ->setDescription('Mise à jour des dossiers Cart@DS pour tous les projets')
+            ->setHelp('')
+            ->addArgument('dateModification', InputArgument::OPTIONAL, 'Recherche par date de dernière modification');
+    }
+
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+
+        $dateModification = $input->getArgument('dateModification');
+        if (is_null($dateModification)) {
+            $dateModification = date('Y-m-d', strtotime("-1 days"));
+        } else {
+            if (!preg_match("/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/", $dateModification)) {
+                $output->writeln('`'.$dateModification.'` is not a date');
+                return 1;
+            }
+        }
+
+        $repoList = \lizmap::getRepositoryList();
+
+        foreach ($repoList as  $repo) {
+            $projectList = \lizmap::getRepository($repo)->getProjects();
+            $output->writeln('searching projects on repo '.$repo);
+            foreach ($projectList as $proj) {
+                $projectName = $proj->getKey();
+                $testCartADSProject = cartAdsUtil::projectIsCartADS($repo, $projectName);
+                if ($testCartADSProject == cartAdsUtil::PROJECT_OK) {
+                    $output->writeln('cartAds project '.$repo.'/'.$projectName.' found, updating dossiers');
+                    $this->updateProjectDossier($repo, $projectName, $dateModification, $output);
+                }
+            }
+        }
+
+        return 0;
+    }
+}

--- a/cartads/lib/Commands/UpdateDossiers.php
+++ b/cartads/lib/Commands/UpdateDossiers.php
@@ -7,13 +7,10 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-use \cartADS\dbClient as cartAdsDbClient;
 use \cartADS\Util as cartAdsUtil;
-use \cartADS\AdsCsApiClient as cartAdsApiClient;
-use \carAds\ResultUpdateDossiers;
+use cartADS\UpdateDossierAbstract;
 
-
-class UpdateDossiers extends ModuleCommandAbstract
+class UpdateDossiers extends UpdateDossierAbstract
 {
     protected function configure()
     {
@@ -51,58 +48,7 @@ class UpdateDossiers extends ModuleCommandAbstract
             }
         }
 
-        $output->writeln('Recherche de dossiers modifiés depuis le '.$dateModification);
-        $apiClient = new cartAdsApiClient($repo, $projectName);
-        $limit = 1000;
-        $offset = 0;
-        $dossiers = array();
-        $output->writeln('Récupération des dossiers');
-        while ($limit) {
-            $data = $apiClient->recherche(array(
-                'dateModification' => $dateModification,
-                'limit' => $limit,
-                'offset' => $offset,
-            ));
-            $dossiers = array_merge($dossiers, $data);
-            $output->writeln(count($dossiers).' dossiers récupérés');
-            if (count($data) < $limit) {
-                $limit = 0;
-                $output->writeln('Tous les dossiers ont été récupérées');
-                break;
-            }
-            $offset += $limit;
-        }
-
-        $result = cartAdsDbClient::updateDossiers($repo, $projectName, $dossiers);
-        if ($result->getNbTotal() == 0) {
-            $output->writeln('Aucun dossier mis à jour');
-            return 0;
-        }
-        $nb_total = $result->getNbTotal();
-        $nb_new = $result->getNbNew();
-        $nb_update_parcelles = $result->getNbUpdateParcelles();
-        $message = '';
-        if ($nb_total == 1) {
-            $message = '1 dossier mis à jour';
-        } else {
-            $message = $nb_total.' dossiers mis à jour';
-        }
-        if ($nb_new > 0) {
-            if ($nb_new == 1) {
-                $message .= ' dont 1 nouveau';
-            } else {
-                $message .= ' dont '.$nb_new.' nouveaux';
-            }
-        }
-        if ($nb_update_parcelles > 0) {
-            if ($nb_update_parcelles == 1) {
-                $message .= ' dont 1 dossier';
-            } else {
-                $message .= ' dont '.$nb_update_parcelles.' dossiers';
-            }
-            $message .= ' avec une nouvelle liste de parcelles';
-        }
-        $output->writeln($message);
+        $this->updateProjectDossier($repo, $projectName, $dateModification, $output);
         return 0;
     }
 }

--- a/cartads/lib/UpdateDossierAbstract.php
+++ b/cartads/lib/UpdateDossierAbstract.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace cartADS;
+
+use Jelix\Scripts\ModuleCommandAbstract;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use cartADS\dbClient as cartAdsDbClient;
+use cartADS\AdsCsApiClient as cartAdsApiClient;
+
+abstract class UpdateDossierAbstract extends ModuleCommandAbstract
+{
+    public function updateProjectDossier($repo, $projectName, $dateModification, OutputInterface $output)
+    {
+        $output->writeln('Recherche de dossiers modifiés depuis le '.$dateModification);
+        $apiClient = new cartAdsApiClient($repo, $projectName);
+        $limit = 1000;
+        $offset = 0;
+        $dossiers = array();
+        $output->writeln('Récupération des dossiers');
+        while ($limit) {
+            $data = $apiClient->recherche(array(
+                'dateModification' => $dateModification,
+                'limit' => $limit,
+                'offset' => $offset,
+            ));
+            $dossiers = array_merge($dossiers, $data);
+            $output->writeln(count($dossiers).' dossiers récupérés');
+            if (count($data) < $limit) {
+                $limit = 0;
+                $output->writeln('Tous les dossiers ont été récupérées');
+                break;
+            }
+            $offset += $limit;
+        }
+
+        $result = cartAdsDbClient::updateDossiers($repo, $projectName, $dossiers);
+        if ($result->getNbTotal() == 0) {
+            $output->writeln('Aucun dossier mis à jour');
+            return 0;
+        }
+        $nb_total = $result->getNbTotal();
+        $nb_new = $result->getNbNew();
+        $nb_update_parcelles = $result->getNbUpdateParcelles();
+        $message = '';
+        if ($nb_total == 1) {
+            $message = '1 dossier mis à jour';
+        } else {
+            $message = $nb_total.' dossiers mis à jour';
+        }
+        if ($nb_new > 0) {
+            if ($nb_new == 1) {
+                $message .= ' dont 1 nouveau';
+            } else {
+                $message .= ' dont '.$nb_new.' nouveaux';
+            }
+        }
+        if ($nb_update_parcelles > 0) {
+            if ($nb_update_parcelles == 1) {
+                $message .= ' dont 1 dossier';
+            } else {
+                $message .= ' dont '.$nb_update_parcelles.' dossiers';
+            }
+            $message .= ' avec une nouvelle liste de parcelles';
+        }
+        $output->writeln($message);
+    }
+}


### PR DESCRIPTION
 - refacto pour faire une classe abstraite qui met à jour les dossier d'un projet.
 - reprise de la  commande `update:dossier` pour utiliser cette classe
 - ajoute une commande `update:dossier:all`
 